### PR TITLE
Allow Subtypes of HalRepresentation in withEmbedded

### DIFF
--- a/src/main/java/de/otto/edison/hal/HalRepresentation.java
+++ b/src/main/java/de/otto/edison/hal/HalRepresentation.java
@@ -131,7 +131,7 @@ public class HalRepresentation {
      *
      * @since 0.5.0
      */
-    protected void withEmbedded(final String rel, final List<HalRepresentation> embeddedItems) {
+    protected void withEmbedded(final String rel, final List<? extends HalRepresentation> embeddedItems) {
         embedded = copyOf(embedded).with(rel, embeddedItems).build().withCuries(getLinks().getLinksBy(CURIES));
     }
 


### PR DESCRIPTION
Currenlty one can not easily embedd some `Foo extends HalRepresentation`.